### PR TITLE
Restrict friendly-time dependency to resolve build errors. Fixes #7

### DIFF
--- a/lambdacms-core.cabal
+++ b/lambdacms-core.cabal
@@ -65,7 +65,7 @@ library
                   , shakespeare
                   , uuid                               >= 1.3.3    && < 1.4
                   , time                               >= 1.4.2    && < 1.5
-                  , friendly-time                      >= 0.3      && < 1.0
+                  , friendly-time                      == 0.3
                   , old-locale                         >= 1.0.0.5  && < 1.0.1.0
                   , mime-mail                          >= 0.4.5.2  && < 0.5
                   , blaze-html


### PR DESCRIPTION
`friendly-time-0.4` changes API, breaks the build if less restrictive bounds are specified.